### PR TITLE
Use ignore_index for the loss and add support for infrared band in the Heads

### DIFF
--- a/satlaspretrain_models/model.py
+++ b/satlaspretrain_models/model.py
@@ -210,11 +210,9 @@ class Model(torch.nn.Module):
                 "regress", backbone_channels, num_categories, ignore_index
             )
         elif head == Head.DETECT:
-            return FRCNNHead("detect", backbone_channels, num_categories, ignore_index)
+            return FRCNNHead("detect", backbone_channels, num_categories)
         elif head == Head.INSTANCE:
-            return FRCNNHead(
-                "instance", backbone_channels, num_categories, ignore_index
-            )
+            return FRCNNHead("instance", backbone_channels, num_categories)
         return None
 
     def forward(self, imgs, targets=None):

--- a/satlaspretrain_models/model.py
+++ b/satlaspretrain_models/model.py
@@ -1,15 +1,16 @@
-import torch
-import torch.nn
-import requests
 from io import BytesIO
 
+import requests
+import torch
+import torch.nn
+
+from satlaspretrain_models.models import *
 from satlaspretrain_models.utils import (
     Backbone,
     Head,
     SatlasPretrain_weights,
     adjust_state_dict_prefix,
 )
-from satlaspretrain_models.models import *
 
 
 class Weights:
@@ -26,7 +27,7 @@ class Weights:
         head=None,
         num_categories=None,
         device="cuda",
-        infra=0,
+        additional_bands=0,
         ignore_index=255,
     ):
         """
@@ -73,7 +74,7 @@ class Weights:
             head=head,
             num_categories=num_categories,
             weights=weights,
-            infra=infra,
+            additional_bands=additional_bands,
             ignore_index=ignore_index,
         )
         return model
@@ -89,7 +90,7 @@ class Model(torch.nn.Module):
         head=None,
         num_categories=None,
         weights=None,
-        infra=0,
+        additional_bands=0,
         ignore_index=255,
     ):
         """
@@ -131,7 +132,7 @@ class Model(torch.nn.Module):
             self.head = (
                 self._initialize_head(
                     head,
-                    [[x, y + infra] for x, y in self.fpn.out_channels],
+                    [[x, y + additional_bands] for x, y in self.fpn.out_channels],
                     num_categories,
                     ignore_index,
                 )

--- a/satlaspretrain_models/models/heads.py
+++ b/satlaspretrain_models/models/heads.py
@@ -10,17 +10,21 @@ class NoopTransform(torch.nn.Module):
     def __init__(self):
         super(NoopTransform, self).__init__()
 
-        self.transform = torchvision.models.detection.transform.GeneralizedRCNNTransform(
-            min_size=800,
-            max_size=800,
-            image_mean=[],
-            image_std=[],
+        self.transform = (
+            torchvision.models.detection.transform.GeneralizedRCNNTransform(
+                min_size=800,
+                max_size=800,
+                image_mean=[],
+                image_std=[],
+            )
         )
 
     def forward(self, images, targets):
         images = self.transform.batch_images(images, size_divisible=32)
         image_sizes = [(image.shape[1], image.shape[2]) for image in images]
-        image_list = torchvision.models.detection.image_list.ImageList(images, image_sizes)
+        image_list = torchvision.models.detection.image_list.ImageList(
+            images, image_sizes
+        )
         return image_list, targets
 
     def postprocess(self, detections, image_sizes, orig_sizes):
@@ -34,7 +38,7 @@ class FRCNNHead(torch.nn.Module):
         self.task_type = task
         self.use_layers = list(range(len(backbone_channels)))
         num_channels = backbone_channels[self.use_layers[0]][1]
-        featmap_names = ['feat{}'.format(i) for i in range(len(self.use_layers))]
+        featmap_names = ["feat{}".format(i) for i in range(len(self.use_layers))]
         num_classes = num_categories
 
         self.noop_transform = NoopTransform()
@@ -42,8 +46,14 @@ class FRCNNHead(torch.nn.Module):
         # RPN
         anchor_sizes = [[32], [64], [128], [256]]
         aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
-        rpn_anchor_generator = torchvision.models.detection.anchor_utils.AnchorGenerator(anchor_sizes, aspect_ratios)
-        rpn_head = torchvision.models.detection.rpn.RPNHead(num_channels, rpn_anchor_generator.num_anchors_per_location()[0])
+        rpn_anchor_generator = (
+            torchvision.models.detection.anchor_utils.AnchorGenerator(
+                anchor_sizes, aspect_ratios
+            )
+        )
+        rpn_head = torchvision.models.detection.rpn.RPNHead(
+            num_channels, rpn_anchor_generator.num_anchors_per_location()[0]
+        )
         rpn_fg_iou_thresh = 0.7
         rpn_bg_iou_thresh = 0.3
         rpn_batch_size_per_image = 256
@@ -64,9 +74,15 @@ class FRCNNHead(torch.nn.Module):
         )
 
         # ROI
-        box_roi_pool = torchvision.ops.MultiScaleRoIAlign(featmap_names=featmap_names, output_size=7, sampling_ratio=2)
-        box_head = torchvision.models.detection.faster_rcnn.TwoMLPHead(backbone_channels[0][1] * box_roi_pool.output_size[0] ** 2, 1024)
-        box_predictor = torchvision.models.detection.faster_rcnn.FastRCNNPredictor(1024, num_classes)
+        box_roi_pool = torchvision.ops.MultiScaleRoIAlign(
+            featmap_names=featmap_names, output_size=7, sampling_ratio=2
+        )
+        box_head = torchvision.models.detection.faster_rcnn.TwoMLPHead(
+            backbone_channels[0][1] * box_roi_pool.output_size[0] ** 2, 1024
+        )
+        box_predictor = torchvision.models.detection.faster_rcnn.FastRCNNPredictor(
+            1024, num_classes
+        )
         box_fg_iou_thresh = 0.5
         box_bg_iou_thresh = 0.5
         box_batch_size_per_image = 512
@@ -89,17 +105,27 @@ class FRCNNHead(torch.nn.Module):
             box_detections_per_img,
         )
 
-        if self.task_type == 'instance':
+        if self.task_type == "instance":
             # Use Mask R-CNN stuff.
-            self.roi_heads.mask_roi_pool = torchvision.ops.MultiScaleRoIAlign(featmap_names=featmap_names, output_size=14, sampling_ratio=2)
+            self.roi_heads.mask_roi_pool = torchvision.ops.MultiScaleRoIAlign(
+                featmap_names=featmap_names, output_size=14, sampling_ratio=2
+            )
 
             mask_layers = (256, 256, 256, 256)
             mask_dilation = 1
-            self.roi_heads.mask_head = torchvision.models.detection.mask_rcnn.MaskRCNNHeads(backbone_channels[0][1], mask_layers, mask_dilation)
+            self.roi_heads.mask_head = (
+                torchvision.models.detection.mask_rcnn.MaskRCNNHeads(
+                    backbone_channels[0][1], mask_layers, mask_dilation
+                )
+            )
 
             mask_predictor_in_channels = 256
             mask_dim_reduced = 256
-            self.roi_heads.mask_predictor = torchvision.models.detection.mask_rcnn.MaskRCNNPredictor(mask_predictor_in_channels, mask_dim_reduced, num_classes)
+            self.roi_heads.mask_predictor = (
+                torchvision.models.detection.mask_rcnn.MaskRCNNPredictor(
+                    mask_predictor_in_channels, mask_dim_reduced, num_classes
+                )
+            )
 
     def forward(self, image_list, raw_features, targets=None):
         device = image_list[0].device
@@ -107,12 +133,14 @@ class FRCNNHead(torch.nn.Module):
 
         features = collections.OrderedDict()
         for i, idx in enumerate(self.use_layers):
-            features['feat{}'.format(i)] = raw_features[idx]
+            features["feat{}".format(i)] = raw_features[idx]
 
         proposals, proposal_losses = self.rpn(images, features, targets)
-        detections, detector_losses = self.roi_heads(features, proposals, images.image_sizes, targets)
+        detections, detector_losses = self.roi_heads(
+            features, proposals, images.image_sizes, targets
+        )
 
-        losses = {'base': torch.tensor(0, device=device, dtype=torch.float32)}
+        losses = {"base": torch.tensor(0, device=device, dtype=torch.float32)}
         losses.update(proposal_losses)
         losses.update(detector_losses)
 
@@ -121,50 +149,60 @@ class FRCNNHead(torch.nn.Module):
 
 
 class SimpleHead(torch.nn.Module):
-    def __init__(self, task, backbone_channels, num_categories=2):
+    def __init__(self, task, backbone_channels, num_categories=2, ignore_index=255):
         super(SimpleHead, self).__init__()
 
-        self.task_type = task 
+        self.task_type = task
 
         use_channels = backbone_channels[0][1]
         num_layers = 2
         self.num_outputs = num_categories
         if self.num_outputs is None:
-            if task_type == 'regress':
+            if task_type == "regress":
                 self.num_outputs = 1
             else:
                 self.num_outputs = 2
 
         layers = []
-        for _ in range(num_layers-1):
+        for _ in range(num_layers - 1):
             layer = torch.nn.Sequential(
                 torch.nn.Conv2d(use_channels, use_channels, 3, padding=1),
                 torch.nn.ReLU(inplace=True),
             )
             layers.append(layer)
 
-        if self.task_type == 'segment':
+        if self.task_type == "segment":
             layers.append(torch.nn.Conv2d(use_channels, self.num_outputs, 3, padding=1))
-            self.loss_func = lambda logits, targets: torch.nn.functional.cross_entropy(logits, targets, reduction='none')
+            self.loss_func = lambda logits, targets: torch.nn.functional.cross_entropy(
+                logits, targets, reduction="none", ignore_index=ignore_index
+            )
 
-        elif self.task_type == 'bin_segment':
+        elif self.task_type == "bin_segment":
             layers.append(torch.nn.Conv2d(use_channels, self.num_outputs, 3, padding=1))
+
             def loss_func(logits, targets):
                 targets = targets.argmax(dim=1)
-                return torch.nn.functional.cross_entropy(logits, targets, reduction='none')[:, None, :, :]
+                return torch.nn.functional.cross_entropy(
+                    logits, targets, reduction="none", ignore_index=ignore_index
+                )[:, None, :, :]
+
             self.loss_func = loss_func
 
-        elif self.task_type == 'regress':
+        elif self.task_type == "regress":
             layers.append(torch.nn.Conv2d(use_channels, self.num_outputs, 3, padding=1))
             self.loss_func = lambda outputs, targets: torch.square(outputs - targets)
 
-        elif self.task_type == 'classification':
+        elif self.task_type == "classification":
             self.extra = torch.nn.Linear(use_channels, self.num_outputs)
-            self.loss_func = lambda logits, targets: torch.nn.functional.cross_entropy(logits, targets, reduction='none')
+            self.loss_func = lambda logits, targets: torch.nn.functional.cross_entropy(
+                logits, targets, reduction="none", ignore_index=ignore_index
+            )
 
-        elif self.task_type == 'multi-label-classification':
+        elif self.task_type == "multi-label-classification":
             self.extra = torch.nn.Linear(use_channels, self.num_outputs)
-            self.loss_func = lambda logits, targets: torch.nn.functional.binary_cross_entropy_with_logits(logits, targets, reduction='none')
+            self.loss_func = lambda logits, targets: torch.nn.functional.binary_cross_entropy_with_logits(
+                logits, targets, reduction="none"
+            )
 
         self.layers = torch.nn.Sequential(*layers)
 
@@ -172,7 +210,7 @@ class SimpleHead(torch.nn.Module):
         raw_outputs = self.layers(raw_features[0])
         loss = None
 
-        if self.task_type == 'segment':
+        if self.task_type == "segment":
             outputs = torch.nn.functional.softmax(raw_outputs, dim=1)
 
             if targets is not None:
@@ -180,7 +218,7 @@ class SimpleHead(torch.nn.Module):
                 loss = self.loss_func(raw_outputs, task_targets)
                 loss = loss.mean()
 
-        elif self.task_type == 'bin_segment':
+        elif self.task_type == "bin_segment":
             outputs = torch.nn.functional.softmax(raw_outputs, dim=1)
 
             if targets is not None:
@@ -188,17 +226,17 @@ class SimpleHead(torch.nn.Module):
                 loss = self.loss_func(raw_outputs, task_targets)
                 loss = loss.mean()
 
-        elif self.task_type == 'regress':
+        elif self.task_type == "regress":
             raw_outputs = raw_outputs[:, 0, :, :]
-            outputs = 255*raw_outputs
+            outputs = 255 * raw_outputs
 
             if targets is not None:
                 task_targets = torch.stack([target for target in targets], dim=0).long()
-                loss = self.loss_func(raw_outputs, task_targets.float()/255)
+                loss = self.loss_func(raw_outputs, task_targets.float() / 255)
                 loss = loss.mean()
 
-        elif self.task_type == 'classification':
-            features = torch.amax(raw_outputs, dim=(2,3))
+        elif self.task_type == "classification":
+            features = torch.amax(raw_outputs, dim=(2, 3))
             logits = self.extra(features)
             outputs = torch.nn.functional.softmax(logits, dim=1)
 
@@ -207,8 +245,8 @@ class SimpleHead(torch.nn.Module):
                 loss = self.loss_func(logits, task_targets)
                 loss = loss.mean()
 
-        elif self.task_type == 'multi-label-classification':
-            features = torch.amax(raw_outputs, dim=(2,3))
+        elif self.task_type == "multi-label-classification":
+            features = torch.amax(raw_outputs, dim=(2, 3))
             logits = self.extra(features)
             outputs = torch.sigmoid(logits)
 
@@ -218,4 +256,3 @@ class SimpleHead(torch.nn.Module):
                 loss = loss.mean()
 
         return outputs, loss
-

--- a/tests/test_pretrained_models.py
+++ b/tests/test_pretrained_models.py
@@ -4,48 +4,71 @@ import torch
 from satlaspretrain_models.model import Weights
 from satlaspretrain_models.utils import SatlasPretrain_weights, Head
 
+
 # Fixture for weights manager
 @pytest.fixture(scope="module")
 def weights_manager():
     return Weights()
+
 
 # Test loading pretrained backbone models without FPN or Head
 @pytest.mark.parametrize("model_id", SatlasPretrain_weights.keys())
 def test_pretrained_backbone(weights_manager, model_id):
     model_info = SatlasPretrain_weights[model_id]
     model = weights_manager.get_pretrained_model(model_id)
-    rand_img = torch.rand((8, model_info['num_channels'], 128, 128)).float()
+    rand_img = torch.rand((8, model_info["num_channels"], 128, 128)).float()
     output = model(rand_img)
     assert output is not None
+
 
 # Test loading pretrained backbone models with FPN, without Head
 @pytest.mark.parametrize("model_id", SatlasPretrain_weights.keys())
 def test_pretrained_backbone_with_fpn(weights_manager, model_id):
     model_info = SatlasPretrain_weights[model_id]
     model = weights_manager.get_pretrained_model(model_id, fpn=True)
-    rand_img = torch.rand((8, model_info['num_channels'], 128, 128)).float()
+    rand_img = torch.rand((8, model_info["num_channels"], 128, 128)).float()
     output = model(rand_img)
     assert output is not None
 
-# Test loading pretrained backbones with FPN and every possible Head
-@pytest.mark.parametrize("model_id,head", [(model_id, head) for model_id in SatlasPretrain_weights.keys() for head in Head])
-def test_pretrained_backbone_with_fpn_and_head(weights_manager, model_id, head):
+
+# Test loading pretrained backbones with FPN, every possible Head and every possible infra
+@pytest.mark.parametrize(
+    "model_id,head,infra",
+    [
+        (model_id, head, infra)
+        for model_id in SatlasPretrain_weights.keys()
+        for head in Head
+        for infra in [0, 1]
+    ],
+)
+def test_pretrained_backbone_with_fpn_and_head(weights_manager, model_id, head, infra):
     model_info = SatlasPretrain_weights[model_id]
-    model = weights_manager.get_pretrained_model(model_id, fpn=True, head=head, num_categories=2)
-    rand_img = torch.rand((1, model_info['num_channels'], 128, 128)).float()
+    model = weights_manager.get_pretrained_model(
+        model_id, fpn=True, head=head, num_categories=2, infra=infra
+    )
+    rand_img = torch.rand((1, model_info["num_channels"], 128, 128)).float()
+    rand_ir = torch.rand((1, 1, 128, 128)).float()
 
     rand_targets = None
     if head == Head.DETECT:
-        rand_targets = [{
-            'boxes': torch.tensor([[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32),
-            'labels': torch.tensor([0,1], dtype=torch.int64)
-        }]
+        rand_targets = [
+            {
+                "boxes": torch.tensor(
+                    [[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32
+                ),
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+            }
+        ]
     elif head == Head.INSTANCE:
-        rand_targets = [{
-            'boxes': torch.tensor([[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32),
-            'labels': torch.tensor([0,1], dtype=torch.int64),
-            'masks': torch.zeros_like(rand_img)
-        }]
+        rand_targets = [
+            {
+                "boxes": torch.tensor(
+                    [[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32
+                ),
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+                "masks": torch.zeros_like(rand_img),
+            }
+        ]
     elif head == Head.BINSEGMENT:
         rand_targets = torch.zeros((1, 2, 32, 32))
     elif head == Head.REGRESS:
@@ -56,9 +79,17 @@ def test_pretrained_backbone_with_fpn_and_head(weights_manager, model_id, head):
     # TODO: add rand_targets for SEGMENT and MULTICLASSIFY
 
     if rand_targets is not None:
-        output, loss = model(rand_img, rand_targets)
+        out = model.backbone(rand_img)
+        out = model.fpn(out)
+        out = model.upsample(out)
+        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
+        output, loss = model.head(rand_img, out, rand_targets)
         assert output is not None
         assert loss is not None
     else:
-        output = model(rand_img)
+        out = model.backbone(rand_img)
+        out = model.fpn(out)
+        out = model.upsample(out)
+        out[0] = torch.cat((out[0], rand_ir), dim=1)
+        output = model.head(rand_img, out)
         assert output is not None

--- a/tests/test_pretrained_models.py
+++ b/tests/test_pretrained_models.py
@@ -90,6 +90,6 @@ def test_pretrained_backbone_with_fpn_and_head(weights_manager, model_id, head, 
         out = model.backbone(rand_img)
         out = model.fpn(out)
         out = model.upsample(out)
-        out[0] = torch.cat((out[0], rand_ir), dim=1)
+        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
         output = model.head(rand_img, out)
         assert output is not None

--- a/tests/test_randomly_initialized_models.py
+++ b/tests/test_randomly_initialized_models.py
@@ -39,17 +39,17 @@ def test_random_backbone_with_fpn(backbone):
     assert output is not None
 
 
-# Test loading pretrained backbones with FPN, every possible Head and every possible infra
+# Test loading pretrained backbones with FPN, every possible Head and every possible additional_bands
 @pytest.mark.parametrize(
-    "backbone,head,infra",
+    "backbone,head,additional_bands",
     [
-        (backbone, head, infra)
+        (backbone, head, additional_bands)
         for backbone in Backbone
         for head in Head
-        for infra in [0, 1]
+        for additional_bands in [0, 1]
     ],
 )
-def test_random_backbone_with_fpn_and_head(backbone, head, infra):
+def test_random_backbone_with_fpn_and_head(backbone, head, additional_bands):
     model = Model(
         num_channels=3,
         multi_image=False,
@@ -58,7 +58,7 @@ def test_random_backbone_with_fpn_and_head(backbone, head, infra):
         head=head,
         num_categories=2,
         weights=None,
-        infra=infra,
+        additional_bands=additional_bands,
     )
     rand_img = torch.rand((1, 3, 128, 128)).float()
     rand_ir = torch.rand((1, 1, 128, 128)).float()
@@ -96,7 +96,9 @@ def test_random_backbone_with_fpn_and_head(backbone, head, infra):
         out = model.backbone(rand_img)
         out = model.fpn(out)
         out = model.upsample(out)
-        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
+        out[0] = (
+            torch.cat((out[0], rand_ir), dim=1) if additional_bands == 1 else out[0]
+        )
         output, loss = model.head(rand_img, out, rand_targets)
         assert output is not None
         assert loss is not None
@@ -104,6 +106,8 @@ def test_random_backbone_with_fpn_and_head(backbone, head, infra):
         out = model.backbone(rand_img)
         out = model.fpn(out)
         out = model.upsample(out)
-        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
+        out[0] = (
+            torch.cat((out[0], rand_ir), dim=1) if additional_bands == 1 else out[0]
+        )
         output = model.head(rand_img, out)
         assert output is not None

--- a/tests/test_randomly_initialized_models.py
+++ b/tests/test_randomly_initialized_models.py
@@ -4,40 +4,85 @@ import torch
 from satlaspretrain_models.model import Model
 from satlaspretrain_models.utils import Backbone, Head
 
+
 # Test loading randomly initialized backbone models without FPN or Head
 @pytest.mark.parametrize("backbone", [backbone for backbone in Backbone])
 def test_random_backbone(backbone):
-    model = Model(num_channels=3, multi_image=False, backbone=backbone, fpn=False, head=None, num_categories=None, weights=None)
+    model = Model(
+        num_channels=3,
+        multi_image=False,
+        backbone=backbone,
+        fpn=False,
+        head=None,
+        num_categories=None,
+        weights=None,
+    )
     rand_img = torch.rand((8, 3, 128, 128)).float()
     output = model(rand_img)
     assert output is not None
+
 
 # Test loading randomly initialized backbone models with FPN, without Head
 @pytest.mark.parametrize("backbone", [backbone for backbone in Backbone])
 def test_random_backbone_with_fpn(backbone):
-    model = Model(num_channels=3, multi_image=False, backbone=backbone, fpn=True, head=None, num_categories=None, weights=None)
+    model = Model(
+        num_channels=3,
+        multi_image=False,
+        backbone=backbone,
+        fpn=True,
+        head=None,
+        num_categories=None,
+        weights=None,
+    )
     rand_img = torch.rand((8, 3, 128, 128)).float()
     output = model(rand_img)
     assert output is not None
 
-# Test loading pretrained backbones with FPN and every possible Head
-@pytest.mark.parametrize("backbone,head", [(backbone, head) for backbone in Backbone for head in Head])
-def test_random_backbone_with_fpn_and_head(backbone, head):
-    model = Model(num_channels=3, multi_image=False, backbone=backbone, fpn=True, head=head, num_categories=2, weights=None)
+
+# Test loading pretrained backbones with FPN, every possible Head and every possible infra
+@pytest.mark.parametrize(
+    "backbone,head,infra",
+    [
+        (backbone, head, infra)
+        for backbone in Backbone
+        for head in Head
+        for infra in [0, 1]
+    ],
+)
+def test_random_backbone_with_fpn_and_head(backbone, head, infra):
+    model = Model(
+        num_channels=3,
+        multi_image=False,
+        backbone=backbone,
+        fpn=True,
+        head=head,
+        num_categories=2,
+        weights=None,
+        infra=infra,
+    )
     rand_img = torch.rand((1, 3, 128, 128)).float()
+    rand_ir = torch.rand((1, 1, 128, 128)).float()
 
     rand_targets = None
     if head == Head.DETECT:
-        rand_targets = [{
-            'boxes': torch.tensor([[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32),
-            'labels': torch.tensor([0,1], dtype=torch.int64)
-        }]
+        rand_targets = [
+            {
+                "boxes": torch.tensor(
+                    [[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32
+                ),
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+            }
+        ]
     elif head == Head.INSTANCE:
-        rand_targets = [{
-            'boxes': torch.tensor([[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32),
-            'labels': torch.tensor([0,1], dtype=torch.int64),
-            'masks': torch.zeros_like(rand_img)
-        }]
+        rand_targets = [
+            {
+                "boxes": torch.tensor(
+                    [[100, 100, 110, 110], [30, 30, 40, 40]], dtype=torch.float32
+                ),
+                "labels": torch.tensor([0, 1], dtype=torch.int64),
+                "masks": torch.zeros_like(rand_img),
+            }
+        ]
     elif head == Head.BINSEGMENT:
         rand_targets = torch.zeros((1, 2, 32, 32))
     elif head == Head.REGRESS:
@@ -48,7 +93,11 @@ def test_random_backbone_with_fpn_and_head(backbone, head):
     # TODO: add rand_targets for SEGMENT and MULTICLASSIFY
 
     if rand_targets is not None:
-        output, loss = model(rand_img, rand_targets)
+        out = model.backbone(rand_img)
+        out = model.fpn(out)
+        out = model.upsample(out)
+        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
+        output, loss = model.head(rand_img, out, rand_targets)
         assert output is not None
         assert loss is not None
     else:

--- a/tests/test_randomly_initialized_models.py
+++ b/tests/test_randomly_initialized_models.py
@@ -101,5 +101,9 @@ def test_random_backbone_with_fpn_and_head(backbone, head, infra):
         assert output is not None
         assert loss is not None
     else:
-        output = model(rand_img)
+        out = model.backbone(rand_img)
+        out = model.fpn(out)
+        out = model.upsample(out)
+        out[0] = torch.cat((out[0], rand_ir), dim=1) if infra == 1 else out[0]
+        output = model.head(rand_img, out)
         assert output is not None


### PR DESCRIPTION
# Contents
This PR brings two features:

- Use an `ignore_index` argument for ignoring a value (e.g. no-data value) while computing the cross entropy loss
- Add any additional channel to the input of the Segmentation Head

# Exemple Usage
```python
import satlaspretrain_models
import torch

num_classes = 10
# load model
model = satlaspretrain_models.Weights().get_pretrained_model(
    model_identifier="Aerial_SwinB_SI",
    fpn=True,
    head=satlaspretrain_models.Head.SEGMENT,
    num_categories=num_classes,
    additional_bands=1,
    ignore_index=255,
)

# freeze backbone, fpn and unfreeze upsampler and head
for param in model.parameters():
    param.requires_grad = False
for param in model.upsample.parameters():
    param.requires_grad = True
for param in model.head.parameters():
    param.requires_grad = True

batch_size = 8
num_channels = 3 + 1 # rgb and infrared

# dummy input 
x = torch.randint(0, 256, (batch_size, num_channels, 512, 512)).float() / 255.0
# dummy mask
y = torch.randint(0, num_classes, (batch_size, 512, 512))

model_input = x[:, :3, :, :]
other_bands = x[:, 3:, :, :]
# compute model outputs
out_backbone = model.backbone(model_input)
out_fpn = model.fpn(out_backbone)
out_upsample = model.upsample(out_fpn)

# add infrared data to the output of the upsampler (at index 0 since it is the only one used in the head)
out_upsample[0] = torch.cat((out_upsample[0], other_bands.unsqueeze(1)), dim=1)
# run the head
probas, loss = model.head(model_input, out_upsample, y)
y_hat = torch.argmax(probas, dim=1) # predictions
```